### PR TITLE
Allow compatibility with HAML 5

### DIFF
--- a/lib/haml_user_tags/compiler.rb
+++ b/lib/haml_user_tags/compiler.rb
@@ -11,7 +11,7 @@ module HamlUserTags
     def convert_user_tag_to_script(node)
       t = node.value
       attributes = t[:attributes]
-      attributes_hashes = [t[:dynamic_attributes].old] || [{}]
+      attributes_hashes = [t[:dynamic_attributes].old || {}]
       object_ref = t[:object_ref]
 
       if object_ref == "nil" and attributes.length == 0 and attributes_hashes.empty?

--- a/lib/haml_user_tags/compiler.rb
+++ b/lib/haml_user_tags/compiler.rb
@@ -11,7 +11,7 @@ module HamlUserTags
     def convert_user_tag_to_script(node)
       t = node.value
       attributes = t[:attributes]
-      attributes_hashes = t[:attributes_hashes]
+      attributes_hashes = t[:dynamic_attributes].old || {}
       object_ref = t[:object_ref]
 
       if object_ref == "nil" and attributes.length == 0 and attributes_hashes.empty?

--- a/lib/haml_user_tags/compiler.rb
+++ b/lib/haml_user_tags/compiler.rb
@@ -11,7 +11,7 @@ module HamlUserTags
     def convert_user_tag_to_script(node)
       t = node.value
       attributes = t[:attributes]
-      attributes_hashes = t[:dynamic_attributes].old || {}
+      attributes_hashes = [t[:dynamic_attributes].old] || [{}]
       object_ref = t[:object_ref]
 
       if object_ref == "nil" and attributes.length == 0 and attributes_hashes.empty?

--- a/lib/haml_user_tags/helpers.rb
+++ b/lib/haml_user_tags/helpers.rb
@@ -7,9 +7,9 @@ module HamlUserTags
     def self.attributes_hash(class_id, obj_ref, *attributes_hashes)
       attributes = class_id
       attributes_hashes.each do |old|
-        Haml::Buffer.merge_attrs(attributes, Hash[old.map {|k, v| [k.to_s, v]}])
+        Haml::Buffer.merge_attributes!(attributes, Hash[old.map {|k, v| [k.to_s, v]}])
       end
-      Haml::Buffer.merge_attrs(attributes, Haml::Buffer.new.parse_object_ref(obj_ref)) if obj_ref
+      Haml::Buffer.merge_attributes!(attributes, Haml::Buffer.new.parse_object_ref(obj_ref)) if obj_ref
       attributes
     end
 


### PR DESCRIPTION
As part of our Rails upgrade, I have have introduced the changes explained in [this comment](https://github.com/CGamesPlay/haml_user_tags/issues/6#issuecomment-857337329) which in turn allows us to continue using the `haml_user_tags` gem for the time being.